### PR TITLE
Accept several correlation ID headers

### DIFF
--- a/lib/trigger-handler.js
+++ b/lib/trigger-handler.js
@@ -8,7 +8,7 @@ export default async function triggerHandler(recipeMap, req, res) {
   const key = namespace && sequence ? `trigger.${namespace}.${sequence}` : `trigger.${name}`;
   const message = req.body;
 
-  const correlationId = req.headers["x-correlation-id"] || v4();
+  const correlationId = req.headers["x-correlation-id"] || req.headers["correlation-id"] || v4();
   const logger = buildLogger(correlationId);
   logger.info(`incoming http trigger on ${key}`);
   if (namespace && sequence) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/b0rker",
-      "version": "4.5.1",
+      "version": "4.5.2",
       "license": "MIT",
       "dependencies": {
         "@bonniernews/gcp-push-metrics": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "engines": {
     "node": ">=16 <=18"
   },


### PR DESCRIPTION
`lu-common`'s HTTP lib sends the correlation ID as `correlation-id`, but we don't listen to that here, so we've always created a new one. This should help with that, making error tracing a lot easier.