### PR TITLE
Fix sub-sequences triggering main sequence continuation several times

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,12 +49,14 @@ export function start({ recipes, triggers, startServer = true }) {
 
   app.use(router);
 
+  /* c8 ignore start */
   if (startServer) {
     const port = process.env.PORT || 8080;
     app.listen(port, () => {
       buildLogger().info(`${config.appName}: listening on port ${port}, env ${config.envName}`);
     });
   }
+  /* c8 ignore stop */
 
   return app;
 }

--- a/lib/job-storage/firestore-job-storage.js
+++ b/lib/job-storage/firestore-job-storage.js
@@ -85,11 +85,16 @@ async function completedCheck(parentCorrelationId) {
 
 async function removeParent(parentCorrelationId) {
   const logger = buildLogger(parentCorrelationId, "removeParent");
+  let res;
   try {
-    const res = await db.runTransaction(async (t) => {
+    res = await db.runTransaction(async (t) => {
       // remove the parent document from the processed collection
       const parentDoc = await db.collection("processed").doc(parentCorrelationId).get();
-      await t.delete(parentDoc.ref);
+      if (!parentDoc.exists) {
+        logger.warn(`Parent ${parentCorrelationId} not found, it has probably been deleted already. Exiting.`);
+        return false;
+      }
+      t.delete(parentDoc.ref);
 
       // when deleting a collection, the recommendation from Google is to delete in batches,
       // but since our collection will only have 100-1000 documents we can just delete them all at once
@@ -98,12 +103,13 @@ async function removeParent(parentCorrelationId) {
       snapshot.docs.forEach((doc) => {
         t.delete(doc.ref);
       });
+      return true;
     });
-    return res;
   } catch (e) {
     logger.error(`Remove parent failed ${e}`);
     throw e;
   }
+  return res;
 }
 
 async function messageAlreadySeen(idempotencyKey, deliveryAttempt) {

--- a/lib/job-storage/firestore-job-storage.js
+++ b/lib/job-storage/firestore-job-storage.js
@@ -75,10 +75,10 @@ async function completedCheck(parentCorrelationId) {
   // scan through all the buckets for our parentCorrelationId and see if all the children are complete
   const querySnapshot = await db.collection(parentCorrelationId).get();
 
-  let completedJobs = [];
+  const completedJobs = new Set();
   for (const doc of querySnapshot.docs) {
     const theseCompletedJobs = doc.get("completedJobs");
-    completedJobs = [ ...new Set([ ...theseCompletedJobs, ...completedJobs ]) ];
+    theseCompletedJobs.forEach((job) => completedJobs.add(job));
   }
   return completedJobs;
 }

--- a/lib/job-storage/memory-job-storage.js
+++ b/lib/job-storage/memory-job-storage.js
@@ -76,7 +76,7 @@ function removeParent(parentCorrelationId) {
   const logger = buildLogger(parentCorrelationId, "removeParent");
   logger.info(`Removing parent ${parentCorrelationId}`);
   // we don't delete anything in the memory store, since we want the data to be available for testing
-  return;
+  return true;
 }
 
 function messageAlreadySeen(idempotencyKey, deliveryAttempt) {

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -197,7 +197,16 @@ export default async function messageHandler(recipeMap, req, res) {
           siblingCount,
         });
         if (isLast) {
-          await jobStorage.removeParent(parentCorrelationId);
+          const removedParent = await jobStorage.removeParent(parentCorrelationId);
+          if (!removedParent) {
+            logger.warn(
+              `sub-sequence ${key} finished but parent ${parentCorrelationId} is already removed, probably due to `
+              + "multiple sub-sequences finishing at the same time. Main sequence continuation should already have "
+              + "been triggered, exiting."
+            );
+            return res.status(200).send();
+          }
+
           await publishMessage(
             { ...parentData.message, data: [ ...parentData.message.data, { type: key, id: completedJobCount } ] },
             { key: parentData.nextKey, correlationId, parentCorrelationId }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/b0rker",
-      "version": "7.2.1",
+      "version": "7.3.0",
       "license": "MIT",
       "dependencies": {
         "@bonniernews/gcp-push-metrics": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "engines": {
     "node": ">=16"
   },


### PR DESCRIPTION
Don't trigger main sequence from sub-sequence completed if parent already removed from firestore. This happens when two sub-sequences finish at the exact same time, and both see that all children are complete (so `completedChild` returns `isLast: true`). In this case, we only want to trigger the main sequence once, which should be the one that actually deletes the parent record from firestore.