### PR TITLE
Just ack the message if Firestore says that the parent document already exists

### DIFF
--- a/lib/job-storage/memory-job-storage.js
+++ b/lib/job-storage/memory-job-storage.js
@@ -9,7 +9,11 @@ function storeParent(parentCorrelationId, children, message, nextKey) {
   const logger = buildLogger(parentCorrelationId, "storeParent");
   logger.info(`Storing parent ${parentCorrelationId} with ${children?.length} children`);
   scanForInvalidKeys(message);
-  if (db.processed[parentCorrelationId]) throw Error(`6 ALREADY_EXISTS: Document already exists: memory/databases/(default)/documents/processed/${parentCorrelationId}`);
+  if (db.processed[parentCorrelationId]) {
+    const error = new Error(`6 ALREADY_EXISTS: Document already exists: memory/databases/(default)/documents/processed/${parentCorrelationId}`);
+    error.code = "already-exists";
+    throw error;
+  }
   db.processed[parentCorrelationId] = parentPayload(message, nextKey, children, "memory");
 }
 

--- a/lib/job-storage/memory-job-storage.js
+++ b/lib/job-storage/memory-job-storage.js
@@ -9,6 +9,7 @@ function storeParent(parentCorrelationId, children, message, nextKey) {
   const logger = buildLogger(parentCorrelationId, "storeParent");
   logger.info(`Storing parent ${parentCorrelationId} with ${children?.length} children`);
   scanForInvalidKeys(message);
+  if (db.processed[parentCorrelationId]) throw Error(`6 ALREADY_EXISTS: Document already exists: memory/databases/(default)/documents/processed/${parentCorrelationId}`);
   db.processed[parentCorrelationId] = parentPayload(message, nextKey, children, "memory");
 }
 

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -82,7 +82,7 @@ export default async function messageHandler(recipeMap, req, res) {
     }
     if (error.message.startsWith("6 ALREADY_EXISTS")) {
       logger.error(`Firestore says: ${error.message}`);
-      return 409;
+      return 200; // Just ack the message, we've already triggered the sub-sequence once, no need to do it again. Thanks pub/sub!
     }
     if (deliveryAttempt < 10) {
       logger.warn(`Unexpected error attempt: ${deliveryAttempt} ${error.message}`);

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -80,6 +80,10 @@ export default async function messageHandler(recipeMap, req, res) {
         return 500;
       }
     }
+    if (error.message.startsWith("6 ALREADY_EXISTS")) {
+      logger.error(`Firestore says: ${error.message}`);
+      return 409;
+    }
     if (deliveryAttempt < 10) {
       logger.warn(`Unexpected error attempt: ${deliveryAttempt} ${error.message}`);
     } else {

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -80,7 +80,7 @@ export default async function messageHandler(recipeMap, req, res) {
         return 500;
       }
     }
-    if (error.message.startsWith("6 ALREADY_EXISTS")) {
+    if (error.code === "already-exists") {
       logger.error(`Firestore says: ${error.message}`);
       return 200; // Just ack the message, we've already triggered the sub-sequence once, no need to do it again. Thanks pub/sub!
     }


### PR DESCRIPTION
This line of code:
```
logger.warn(`Unexpected error attempt: ${deliveryAttempt} ${error.message}`);
```

Gives us e.g. the following in logs:
```
Unexpected error attempt: 3 6 ALREADY_EXISTS: Document already exists: ...
```

So this PR should work to catch errors where pub/sub makes us process the same trigger for child processes twice.