### PR TITLE
Ensure message correlation is correct when completing a set of child sub-sequences

### DIFF
--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -210,10 +210,10 @@ export default async function messageHandler(recipeMap, req, res) {
             );
             return res.status(200).send();
           }
-
+          const originalCorrelationId = parentCorrelationId.split(":").slice(1).join(":");
           await publishMessage(
             { ...parentData.message, data: [ ...parentData.message.data, { type: key, id: completedJobCount } ] },
-            { key: parentData.nextKey, correlationId, parentCorrelationId }
+            { key: parentData.nextKey, correlationId: originalCorrelationId }
           );
         }
       } catch (error) {


### PR DESCRIPTION
Make sure we continue the parent sequence with it's original correlationId instead of continuing with the correlationId of the final child.