### PR TITLE
Chunk deleting sequence children from firestore

### DIFF
--- a/lib/job-storage/firestore-job-storage.js
+++ b/lib/job-storage/firestore-job-storage.js
@@ -85,31 +85,34 @@ async function completedCheck(parentCorrelationId) {
 
 async function removeParent(parentCorrelationId) {
   const logger = buildLogger(parentCorrelationId, "removeParent");
-  let res;
   try {
-    res = await db.runTransaction(async (t) => {
-      // remove the parent document from the processed collection
-      const parentDoc = await db.collection("processed").doc(parentCorrelationId).get();
-      if (!parentDoc.exists) {
-        logger.warn(`Parent ${parentCorrelationId} not found, it has probably been deleted already. Exiting.`);
-        return false;
-      }
-      t.delete(parentDoc.ref);
+    // remove the parent document from the processed collection
+    const parentDoc = await db.collection("processed").doc(parentCorrelationId).get();
+    if (!parentDoc.exists) {
+      logger.warn(`Parent ${parentCorrelationId} not found, it has probably been deleted already. Exiting.`);
+      return false;
+    }
+    await parentDoc.ref.delete();
 
-      // when deleting a collection, the recommendation from Google is to delete in batches,
-      // but since our collection will only have 100-1000 documents we can just delete them all at once
-      const bucketsRef = db.collection(parentCorrelationId);
-      const snapshot = await bucketsRef.get();
+    // remove all children, in chunks of 100
+    const bucketsRef = db.collection(parentCorrelationId);
+    const query = bucketsRef.orderBy("__name__").limit(100);
+
+    let snapshot;
+    while ((snapshot = await query.get()).size > 0) {
+      logger.info(`Removing ${snapshot.size} children for parent ${parentCorrelationId}`);
+      const batch = db.batch();
       snapshot.docs.forEach((doc) => {
-        t.delete(doc.ref);
+        batch.delete(doc.ref);
       });
-      return true;
-    });
+      await batch.commit();
+    }
+    logger.info(`Removed all children for parent ${parentCorrelationId}`);
+    return true;
   } catch (e) {
     logger.error(`Remove parent failed ${e}`);
     throw e;
   }
-  return res;
 }
 
 async function messageAlreadySeen(idempotencyKey, deliveryAttempt) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "7.4.3",
+  "version": "7.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/b0rker",
-      "version": "7.4.3",
+      "version": "7.5.0",
       "license": "MIT",
       "dependencies": {
         "@bonniernews/gcp-push-metrics": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "7.4.3",
+  "version": "7.5.0",
   "engines": {
     "node": ">=16"
   },


### PR DESCRIPTION
Firestore transactions have a size limit that we've hit a couple of times. We don't really need to do these deletions in a transaction since it's just cleanup, so let's do it in batches of 100.