### PR TITLE
Cloud Tasks queue routing

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -13,7 +13,8 @@
     "localPort": 8123,
     "selfUrl": "http://host.docker.internal:8080",
     "queues": {
-      "default": "projects/project-id/locations/location/queues/foo-queue"
+      "default": "projects/project-id/locations/location/queues/foo-queue",
+      "concurrencyLimited": "projects/project-id/locations/location/queues/limited-queue"
     }
   },
   "maxResumeCount": 10,

--- a/config/test.json
+++ b/config/test.json
@@ -13,7 +13,8 @@
     "localPort": 8123,
     "selfUrl": "https://b0rker.bn.nr",
     "queues": {
-      "default": "projects/project-id/locations/location/queues/foo-queue"
+      "default": "projects/project-id/locations/location/queues/foo-queue",
+      "concurrencyLimited": "projects/project-id/locations/location/queues/limited-queue"
     }
   },
   "gcpProxy": {

--- a/index.js
+++ b/index.js
@@ -12,10 +12,9 @@ import cloudTasksRouter from "./lib/cloud-tasks/router.js";
 
 export { default as buildContext } from "./lib/context.js";
 
-export function route(key, fn) {
-  const result = {};
-  result[key] = fn;
-  return result;
+export function route(key, fn, { queue } = {}) {
+  if (fn) fn.queue = queue; // Ugly hack to pass the queue along to the cloud tasks router, remove when removing pubsub support
+  return { [key]: fn };
 }
 
 export function start({ recipes, triggers, startServer = true }) {

--- a/lib/cloud-tasks/publish-task.js
+++ b/lib/cloud-tasks/publish-task.js
@@ -44,7 +44,7 @@ export async function publishTasksBulk(taskUrl, messages) {
   logger.info(`Published ${numTasks} tasks`);
 }
 
-export async function publishTask(taskUrl, body, headers = {}) {
+export async function publishTask(taskUrl, body, headers = {}, queue = "default") {
   const url = `${selfUrl}/v2/${taskUrl.replace(/^\//, "")}`;
   const correlationId =
     headers.correlationId || headers["correlation-id"] || luLogger.debugMeta.getDebugMeta().correlationId;
@@ -54,11 +54,12 @@ export async function publishTask(taskUrl, body, headers = {}) {
     idempotencyKey: uuid.v4(),
     ...filterUndefinedNullValues(headers),
   };
+  const queueName = queues[queue] || queues.default;
   logger.info(`Sending task ${JSON.stringify(body)} with headers ${JSON.stringify(newHeaders)} to ${url}`);
   await cloudTasksClient.createTask({
-    parent: queues.default,
+    parent: queueName,
     task: {
-      name: taskNameFromUrl(taskUrl, queues.default, correlationId),
+      name: taskNameFromUrl(taskUrl, queueName, correlationId),
       httpRequest: {
         httpMethod: "POST",
         headers: newHeaders,

--- a/lib/cloud-tasks/router.js
+++ b/lib/cloud-tasks/router.js
@@ -30,30 +30,31 @@ function buildCloudTaskTriggerRoutes(router, triggers) {
 }
 
 function buildCloudTaskSequenceRoutes(router, { namespace, name, sequence, unrecoverable }, nextKeyMapper) {
-  for (const [ key, func ] of sequenceIterator(sequence)) {
+  for (const { key, func } of sequenceIterator(sequence)) {
     router.post(buildUrl(namespace, name, key), messageHandler(func, nextKeyMapper(`${namespace}.${name}.${key}`)));
   }
   // Allow to start a sequence/sub-sequence by posting to the sequence name
-  router.post(`/${namespace}/${name}`, startSequence(sequenceIterator(sequence).next().value[0]));
+  router.post(`/${namespace}/${name}`, startSequence(sequenceIterator(sequence).next().value));
 
   router.post(buildUrl(namespace, name, "processed"), processedHandler);
   router.post(buildUrl(namespace, name, ":taskName/unrecoverable"), unrecoverableHandler(unrecoverable?.[0]?.["*"]));
   router.post(buildUrl(namespace, name, ":taskName/unrecoverable/processed"), processedHandler);
 }
 
-function startSequence(firstKeyInSequence) {
+function startSequence({ key: firstKeyInSequence, queue }) {
   return async (req, res) => {
     const { correlationId, parentCorrelationId, siblingCount } = req.attributes;
     await publishTask(
       `${req.attributes.relativeUrl}/${firstKeyInSequence.replace(/^\./, "")}`,
       appendData(req.body, []), // Ensure we have a data element
-      { correlationId, parentCorrelationId, siblingCount }
+      { correlationId, parentCorrelationId, siblingCount },
+      queue
     );
     res.status(201).send({ correlationId });
   };
 }
 
-function messageHandler(func, nextKey) {
+function messageHandler(func, { nextKey, queue } = {}) {
   return async (req, res) => {
     const { key, correlationId, parentCorrelationId, siblingCount } = req.attributes;
     const context = { ...buildContext(correlationId, key), logger }; // Overwrite the logger with the one from lu-logger;
@@ -63,12 +64,12 @@ function messageHandler(func, nextKey) {
     const nextBody = appendData(req.body, result);
 
     if (result?.type === "trigger") {
-      const triggerResponse = await handleTriggerResult(result, nextBody, nextKey, req.attributes);
+      const triggerResponse = await handleTriggerResult(result, nextBody, { nextKey, queue }, req.attributes);
       if (triggerResponse) return res.status(triggerResponse.status).send(triggerResponse.message);
     }
 
     if (nextKey) {
-      await publishTask(keyToUrl(nextKey), nextBody, { correlationId, parentCorrelationId, siblingCount });
+      await publishTask(keyToUrl(nextKey), nextBody, { correlationId, parentCorrelationId, siblingCount }, queue);
     } else {
       logger.info("No more steps in this sequence");
     }
@@ -76,7 +77,12 @@ function messageHandler(func, nextKey) {
   };
 }
 
-async function handleTriggerResult(result, body, nextKey, { key, correlationId, parentCorrelationId, siblingCount }) {
+async function handleTriggerResult(
+  result,
+  body,
+  { nextKey, queue },
+  { key, correlationId, parentCorrelationId, siblingCount }
+) {
   const errorMessage = checkForTriggerError(result);
   if (errorMessage) {
     logger.error(errorMessage);
@@ -88,7 +94,7 @@ async function handleTriggerResult(result, body, nextKey, { key, correlationId, 
     if (result.messages.length > 0) {
       // If we start sub-sequences, spawn these, and then exit. The main sequence will be resumed
       // when the last child completes
-      await startSubSequences(result, `${key}:${correlationId}`, nextKey, body);
+      await startSubSequences(result, `${key}:${correlationId}`, { nextKey, queue }, body);
       return { message: "Sub-sequences started", status: 200 };
     }
   } else if ([ "sequence", "event" ].some((s) => result.key.startsWith(s))) {
@@ -115,13 +121,13 @@ function checkForTriggerError(result) {
   }
 }
 
-async function startSubSequences(result, parentCorrelationId, nextKey, message) {
+async function startSubSequences(result, parentCorrelationId, { nextKey, queue }, message) {
   const messages = result.messages.map((o) => ({
     body: o,
     headers: { parentCorrelationId, correlationId: uuid.v4() },
   }));
   logger.info(`Starting ${result.messages.length} subsequences`);
-  await jobStorage.storeParent(parentCorrelationId, messages, message, nextKey);
+  await jobStorage.storeParent(parentCorrelationId, messages, message, { nextKey, queue });
   await publishTasksBulk(keyToUrl(result.key), messages);
 }
 
@@ -182,7 +188,12 @@ async function processedHandler(req, res) {
     }
     const originalCorrelationId = parentCorrelationId.split(":").slice(1).join(":");
     const newBody = appendData(parentData.message, { type: key, id: completedJobCount });
-    await publishTask(keyToUrl(parentData.nextKey), newBody, { correlationId: originalCorrelationId });
+    await publishTask(
+      keyToUrl(parentData.nextKey.nextKey),
+      newBody,
+      { correlationId: originalCorrelationId },
+      parentData.nextKey?.queue
+    );
   }
   return res.status(200).send();
 }

--- a/lib/cloud-tasks/utils.js
+++ b/lib/cloud-tasks/utils.js
@@ -5,12 +5,12 @@ export function buildNextKeyMapper(recipes) {
     const iterator = sequenceIterator(sequence);
     const fullKey = (key) => `${namespace}.${name}.${key}`;
 
-    let prevKey = iterator.next().value[0];
-    for (const [ key ] of iterator) {
-      map.set(fullKey(prevKey), fullKey(key));
+    let prevKey = iterator.next().value.key;
+    for (const { key, queue } of iterator) {
+      map.set(fullKey(prevKey), { nextKey: fullKey(key), queue });
       prevKey = key;
     }
-    map.set(fullKey(prevKey), fullKey("processed"));
+    map.set(fullKey(prevKey), { nextKey: fullKey("processed") });
   }
 
   return (k) => map.get(k);
@@ -19,7 +19,7 @@ export function buildNextKeyMapper(recipes) {
 export function* sequenceIterator(sequence) {
   for (const route of sequence) {
     const [ key, func ] = Object.entries(route)[0];
-    yield [ key, func ];
+    yield { key, func, queue: func.queue };
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/b0rker",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "@bonniernews/gcp-push-metrics": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "engines": {
     "node": ">=16"
   },

--- a/test/feature-cloud-tasks/queue-routing.test.js
+++ b/test/feature-cloud-tasks/queue-routing.test.js
@@ -1,0 +1,160 @@
+import { fakeCloudTasks } from "@bonniernews/lu-test";
+import config from "exp-config";
+
+import { start, route } from "../../index.js";
+
+const { queues } = config.cloudTasks;
+
+Feature("Broker sequence with different queues", () => {
+  Scenario("Trigger a sequence with lambdas using multiple queues", () => {
+    let broker;
+    Given("broker is initiated with a recipe", () => {
+      broker = start({
+        startServer: false,
+        recipes: [
+          {
+            namespace: "sequence",
+            name: "foo",
+            sequence: [
+              route(
+                ".perform.step-1",
+                () => {
+                  return { type: "step-1", id: "step-1-was-here" };
+                },
+                { queue: "concurrencyLimited" }
+              ),
+              route(
+                ".perform.step-2",
+                () => {
+                  return { type: "step-2", id: "step-2-was-here" };
+                },
+                { queue: "concurrencyLimited" }
+              ),
+              route(".perform.step-3", () => {
+                return { type: "step-3", id: "step-3-was-here" };
+              }),
+            ],
+          },
+        ],
+      });
+    });
+    const triggerMessage = {
+      type: "foo",
+      id: "some-order-id",
+      correlationId: "some-corr-id",
+    };
+
+    let response;
+    When("a trigger message is received", async () => {
+      response = await fakeCloudTasks.runSequence(broker, "/v2/sequence/foo", triggerMessage);
+    });
+
+    Then("the status code should be 201 Created", () => {
+      response.firstResponse.statusCode.should.eql(201, response.text);
+    });
+
+    And("last message should contain original message and appended data from lambdas", () => {
+      response.messages.slice(-1)[0].message.should.eql({
+        ...triggerMessage,
+        data: [
+          { type: "step-1", id: "step-1-was-here" },
+          { type: "step-2", id: "step-2-was-here" },
+          { type: "step-3", id: "step-3-was-here" },
+        ],
+      });
+    });
+
+    And("the messages should have been published to the correct queues", () => {
+      Object.fromEntries(response.messages.map(({ url, queue }) => [ url, queue ])).should.eql({
+        "/v2/sequence/foo/perform.step-1": queues.concurrencyLimited,
+        "/v2/sequence/foo/perform.step-2": queues.concurrencyLimited,
+        "/v2/sequence/foo/perform.step-3": queues.default,
+        "/v2/sequence/foo/processed": queues.default,
+      });
+    });
+  });
+
+  Scenario("Trigger a sequence with subsequences using multiple queues", () => {
+    let broker;
+    Given("broker is initiated with a recipe", () => {
+      broker = start({
+        startServer: false,
+        recipes: [
+          {
+            namespace: "sequence",
+            name: "foo",
+            sequence: [
+              route(".perform.first", () => {
+                return { type: "first", id: "first-was-here" };
+              }),
+              route(".perform.trigger-subsequences", () => {
+                return { type: "trigger", key: "sub-sequence.bar", messages: [ { attributes: {} } ] };
+              }),
+              route(
+                ".perform.last",
+                () => {
+                  return { type: "last", id: "last-was-here" };
+                },
+                { queue: "concurrencyLimited" }
+              ),
+            ],
+          },
+          {
+            namespace: "sub-sequence",
+            name: "bar",
+            sequence: [
+              route(
+                ".perform.sub-first",
+                () => {
+                  return { type: "first", id: "first-was-here" };
+                },
+                { queue: "concurrencyLimited" }
+              ),
+              route(".perform.sub-last", () => {
+                return { type: "last", id: "last-was-here" };
+              }),
+            ],
+          },
+        ],
+      });
+    });
+    const triggerMessage = {
+      type: "foo-order",
+      id: "some-order-id",
+      correlationId: "some-corr-id",
+    };
+
+    let response;
+    When("a trigger message is received", async () => {
+      response = await fakeCloudTasks.runSequence(broker, "/v2/sequence/foo", triggerMessage);
+    });
+
+    Then("the status code should be 201 Created", () => {
+      response.firstResponse.statusCode.should.eql(201, response.text);
+    });
+
+    And("last message should contain original message and appended data from lambdas", () => {
+      response.messages.slice(-1)[0].message.should.eql({
+        ...triggerMessage,
+        data: [
+          { type: "first", id: "first-was-here" },
+          { type: "sub-sequence.bar.processed", id: 1 },
+          { type: "last", id: "last-was-here" },
+        ],
+      });
+    });
+
+    And("the messages should have been published to the correct queues", () => {
+      Object.fromEntries(response.messages.map(({ url, queue }) => [ url, queue ])).should.eql({
+        "/v2/sequence/foo/perform.first": queues.default,
+        "/v2/sequence/foo/perform.trigger-subsequences": queues.default,
+        "/v2/sub-sequence/bar": queues.default,
+        "/v2/sub-sequence/bar/perform.sub-first": queues.concurrencyLimited,
+        "/v2/sub-sequence/bar/perform.sub-last": queues.default,
+        "/v2/sub-sequence/bar/processed": queues.default,
+        "/v2/sequence/foo/perform.last": queues.concurrencyLimited,
+        "/v2/sequence/foo/processed": queues.default,
+      });
+    });
+  });
+});


### PR DESCRIPTION
Enable using multiple queues, utilizing different rate/concurrency limits.

Note that there always needs to be a `default` queue, and that this is always used for triggers, as well as all "non-lambda messages", such as `/processed`, `/unrecoverable`, etc.