### PR TITLE
Fix Firestore undefined error

### DIFF
--- a/lib/job-storage/firestore-job-storage.js
+++ b/lib/job-storage/firestore-job-storage.js
@@ -4,6 +4,7 @@ import { bucketHash, parentPayload, scanForInvalidKeys } from "./utils/job-stora
 import buildLogger from "../logger.js";
 
 const db = new Firestore();
+db.settings({ ignoreUndefinedProperties: true });
 
 // We store a parent and all child jobs to be started.
 async function storeParent(parentCorrelationId, children, message, nextKey) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/b0rker",
-      "version": "8.1.0",
+      "version": "8.1.1",
       "license": "MIT",
       "dependencies": {
         "@bonniernews/gcp-push-metrics": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "engines": {
     "node": ">=16"
   },


### PR DESCRIPTION
This should fix the error ``Value for argument "data" is not a valid Firestore document. Cannot use "undefined" as a Firestore value (found in field "nextKey.queue"). If you want to ignore undefined values, enable `ignoreUndefinedProperties`.``