### PR TITLE
Make sure all attributes are strings when sending cloud task to DLX

### DIFF
--- a/lib/cloud-tasks/dlx.js
+++ b/lib/cloud-tasks/dlx.js
@@ -9,7 +9,9 @@ export async function sendToDlx(req, errorMessage) {
     {
       origin: "cloudTasks",
       appName: config.appName,
-      ...filterUndefinedNullValues(req.attributes),
+      ...Object.fromEntries(
+        Object.entries(filterUndefinedNullValues(req.attributes)).map(([ key, value ]) => [ key, value.toString() ])
+      ),
     }
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/b0rker",
-      "version": "8.1.1",
+      "version": "8.1.2",
       "license": "MIT",
       "dependencies": {
         "@bonniernews/gcp-push-metrics": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "engines": {
     "node": ">=16"
   },

--- a/test/feature-cloud-tasks/dlx-feature.test.js
+++ b/test/feature-cloud-tasks/dlx-feature.test.js
@@ -117,7 +117,7 @@ Feature("Messages with too many retries get sent to the DLX", () => {
           topic: "b0rker",
           appName: config.appName,
           relativeUrl: "sequence/test/perform.http-step",
-          retryCount: maxRetries + 1,
+          retryCount: (maxRetries + 1).toString(),
         },
       });
     });


### PR DESCRIPTION
PubSub only accepts strings, apparently