### PR TITLE
Add endpoint to resend cloud task

### DIFF
--- a/lib/cloud-tasks/resend.js
+++ b/lib/cloud-tasks/resend.js
@@ -1,0 +1,7 @@
+import { publishTask } from "./publish-task.js";
+
+export default async function resend(req, res) {
+  const { relativeUrl, body, headers, queue } = req.body;
+  await publishTask(relativeUrl, body, headers, queue);
+  res.status(201).send();
+}

--- a/lib/cloud-tasks/router.js
+++ b/lib/cloud-tasks/router.js
@@ -9,6 +9,7 @@ import { appendData, buildNextKeyMapper, buildUrl, keyToUrl, sequenceIterator } 
 import buildContext from "../context.js";
 import jobStorage from "../job-storage/index.js";
 import { sendToDlx } from "./dlx.js";
+import resend from "./resend.js";
 
 export default function cloudTasksRouter(recipes = [], triggers = {}) {
   const router = expressRouter();
@@ -18,6 +19,7 @@ export default function cloudTasksRouter(recipes = [], triggers = {}) {
 
   const nextKeyMapper = buildNextKeyMapper(recipes);
   recipes.forEach((seq) => buildCloudTaskSequenceRoutes(router, seq, nextKeyMapper));
+  router.post("/resend", resend);
   router.use(errorHandler);
   return router;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "8.1.2",
+  "version": "8.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/b0rker",
-      "version": "8.1.2",
+      "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
         "@bonniernews/gcp-push-metrics": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "8.1.2",
+  "version": "8.2.0",
   "engines": {
     "node": ">=16"
   },

--- a/test/feature-cloud-tasks/resend-feature.test.js
+++ b/test/feature-cloud-tasks/resend-feature.test.js
@@ -1,0 +1,57 @@
+import { fakeCloudTasks } from "@bonniernews/lu-test";
+import config from "exp-config";
+
+import { start, route } from "../../index.js";
+
+Feature("Resending a stuck message", () => {
+  afterEachScenario(() => {
+    fakeCloudTasks.reset();
+  });
+
+  Scenario("Resending a message", () => {
+    let broker;
+    Given("broker is initiated with a recipe", () => {
+      broker = start({
+        startServer: false,
+        recipes: [
+          {
+            namespace: "sequence",
+            name: "test",
+            sequence: [
+              route(".perform.first", () => ({ type: "first", id: "1" })),
+              route(".perform.second", () => ({ type: "second", id: "2" })),
+              route(".perform.third", () => ({ type: "third", id: "3" })),
+            ],
+          },
+        ],
+      });
+    });
+
+    let response;
+    When("a trigger message is received", async () => {
+      response = await fakeCloudTasks.runSequence(broker, "/v2/resend", {
+        relativeUrl: "/sequence/test/perform.second",
+        body: {
+          attributes: { foo: "bar" },
+          data: [ { type: "first", id: "1" } ],
+        },
+        headers: { siblingCount: 3 },
+        queue: config.cloudTasks.queues.default,
+      });
+    });
+
+    Then("the status code should be 201 created", () => {
+      response.firstResponse.statusCode.should.eql(201, response.text);
+    });
+
+    And("there sequence should have been processed", () => {
+      response.messages
+        .map(({ url }) => url)
+        .should.eql([
+          "/v2/sequence/test/perform.second",
+          "/v2/sequence/test/perform.third",
+          "/v2/sequence/test/processed",
+        ]);
+    });
+  });
+});


### PR DESCRIPTION
Instead of the DLX needing to know how to resend a cloud task, let the workers handle that themselves.