### PR TITLE
Set Cloud Task name when resending to prevent deduplication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+on:
+  push:
+    branches:
+      - main
+
+name: Create Release
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if package version changed
+        id: check_version
+        run: |
+          version="v$(cat package.json | jq -r '.version')"
+          if [ $(git tag -l "$version") ]; then
+            echo "Tag $version already exists."
+          else
+            echo "version_tag=$version" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Release
+        if: steps.check_version.outputs.version_tag
+        run: |
+          gh release create ${{ steps.check_version.outputs.version_tag }} --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/cloud-tasks/middleware/attributes.js
+++ b/lib/cloud-tasks/middleware/attributes.js
@@ -24,6 +24,7 @@ export function setAttributes(req, res, next) {
     siblingCount: parseInt(req.header("siblingCount")) || undefined,
     idempotencyKey: req.header("idempotencyKey"),
     subSequenceNo: req.header("subSequenceNo"),
+    resendNumber: parseInt(req.header("resendNumber")) || undefined,
     retryCount: parseInt(req.header("x-cloudtasks-taskretrycount") || "0"),
     queue: req.header("x-cloudtasks-queuename"),
   };

--- a/lib/cloud-tasks/publish-task.js
+++ b/lib/cloud-tasks/publish-task.js
@@ -59,7 +59,7 @@ export async function publishTask(taskUrl, body, headers = {}, queue = "default"
   await cloudTasksClient.createTask({
     parent: queueName,
     task: {
-      name: taskNameFromUrl(taskUrl, queueName, correlationId),
+      name: taskNameFromUrl(taskUrl, queueName, correlationId, headers?.resendNumber),
       httpRequest: {
         httpMethod: "POST",
         headers: newHeaders,
@@ -75,9 +75,15 @@ async function setTimer(delaySeconds) {
   return await new Promise((resolve) => setTimeout(resolve, delaySeconds * 1000));
 }
 
-function taskNameFromUrl(url, queueName, correlationId) {
+function taskNameFromUrl(url, queueName, correlationId, resendNumber) {
   // Task name can only contain letters, numbers, underscores and hyphens, and must be at most 500 characters
-  const urlForName = url.replace(/^\//, "").substring(0, 500 - correlationId.length - 2);
-  const name = `${urlForName}__${correlationId}`.replace(/[^\w-]/g, "_");
-  return `${queueName}/tasks/${name}`;
+  const urlForName = url.replace(/^\//, ""); // Remove leading slash
+  const suffix = resendNumber ? `__${correlationId}__re${resendNumber}` : `__${correlationId}`;
+  const truncated = truncateName(urlForName, suffix);
+  const truncatedAndNormalized = truncated.replace(/[^\w-]/g, "_");
+  return `${queueName}/tasks/${truncatedAndNormalized}`;
+}
+
+function truncateName(name, suffix, maxLength = 500) {
+  return (name.substring(0, maxLength - suffix.length) + suffix);
 }

--- a/lib/cloud-tasks/resend.js
+++ b/lib/cloud-tasks/resend.js
@@ -2,6 +2,7 @@ import { publishTask } from "./publish-task.js";
 
 export default async function resend(req, res) {
   const { relativeUrl, body, headers, queue } = req.body;
-  await publishTask(relativeUrl, body, headers, queue);
+  const resendNumber = parseInt(headers?.resendNumber || "0") + 1;
+  await publishTask(relativeUrl, body, { ...headers, resendNumber }, queue);
   res.status(201).send();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       },
       "devDependencies": {
         "@bonniernews/eslint-config": "^1.0.1",
-        "@bonniernews/lu-test": "^9.0.0",
+        "@bonniernews/lu-test": "^9.1.0",
         "c8": "^8.0.1",
         "chai": "^4.3.10",
         "depcheck": "^1.4.7",
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@bonniernews/lu-test": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@bonniernews/lu-test/-/lu-test-9.0.0.tgz",
-      "integrity": "sha512-KUmtk4IUYfiqoAx+aT+qw6VLQ2Oet3B5oG9HcJrtO/vzr3Rr1XT1V6LYxHQqInEp4K6aLLu70r6vsuXxdEg0LQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@bonniernews/lu-test/-/lu-test-9.1.0.tgz",
+      "integrity": "sha512-ZhsvjSnQ2ZYoJXqbWBoHVByMm1XBsm/xg7Lj8AOYkx1oqVba3Z3vohOHSa1TiuSfDUOF4dg2l9WcIy3OS9KjuQ==",
       "dev": true,
       "dependencies": {
         "@google-cloud/pubsub": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@bonniernews/eslint-config": "^1.0.1",
-    "@bonniernews/lu-test": "^9.0.0",
+    "@bonniernews/lu-test": "^9.1.0",
     "c8": "^8.0.1",
     "chai": "^4.3.10",
     "depcheck": "^1.4.7",

--- a/test/feature-cloud-tasks/resend-feature.test.js
+++ b/test/feature-cloud-tasks/resend-feature.test.js
@@ -35,7 +35,7 @@ Feature("Resending a stuck message", () => {
           attributes: { foo: "bar" },
           data: [ { type: "first", id: "1" } ],
         },
-        headers: { siblingCount: 3 },
+        headers: { siblingCount: 3, "correlation-id": "some-epic-id" },
         queue: config.cloudTasks.queues.default,
       });
     });
@@ -51,6 +51,79 @@ Feature("Resending a stuck message", () => {
           "/v2/sequence/test/perform.second",
           "/v2/sequence/test/perform.third",
           "/v2/sequence/test/processed",
+        ]);
+    });
+
+    And("the resend number should be included in the task names", () => {
+      const queue = config.cloudTasks.queues.default;
+      response.messages
+        .map(({ taskName }) => taskName)
+        .should.eql([
+          `${queue}/tasks/sequence_test_perform_second__some-epic-id__re1`,
+          `${queue}/tasks/sequence_test_perform_third__some-epic-id`,
+          `${queue}/tasks/sequence_test_processed__some-epic-id`,
+        ]);
+    });
+  });
+
+  Scenario("Resending a message again", () => {
+    let broker;
+    Given("broker is initiated with a recipe", () => {
+      broker = start({
+        startServer: false,
+        recipes: [
+          {
+            namespace: "sequence",
+            name: "test",
+            sequence: [
+              route(".perform.first", () => ({ type: "first", id: "1" })),
+              route(".perform.second", () => ({ type: "second", id: "2" })),
+              route(".perform.third", () => ({ type: "third", id: "3" })),
+            ],
+          },
+        ],
+      });
+    });
+
+    let response;
+    When("a trigger message is received", async () => {
+      response = await fakeCloudTasks.runSequence(broker, "/v2/resend", {
+        relativeUrl: "/sequence/test/perform.second",
+        body: {
+          attributes: { foo: "bar" },
+          data: [ { type: "first", id: "1" } ],
+        },
+        headers: { siblingCount: 3, "correlation-id": "some-epic-id", resendNumber: 3 },
+        queue: config.cloudTasks.queues.default,
+      });
+    });
+
+    Then("the status code should be 201 created", () => {
+      response.firstResponse.statusCode.should.eql(201, response.text);
+    });
+
+    And("there sequence should have been processed", () => {
+      response.messages
+        .map(({ url }) => url)
+        .should.eql([
+          "/v2/sequence/test/perform.second",
+          "/v2/sequence/test/perform.third",
+          "/v2/sequence/test/processed",
+        ]);
+    });
+
+    And("the resend number should have been increased", () => {
+      response.messages[0].headers.resendNumber.should.eql(4);
+    });
+
+    And("the resend number should be included in the task names", () => {
+      const queue = config.cloudTasks.queues.default;
+      response.messages
+        .map(({ taskName }) => taskName)
+        .should.eql([
+          `${queue}/tasks/sequence_test_perform_second__some-epic-id__re4`,
+          `${queue}/tasks/sequence_test_perform_third__some-epic-id`,
+          `${queue}/tasks/sequence_test_processed__some-epic-id`,
         ]);
     });
   });


### PR DESCRIPTION
Currently, we can't resend a task from the DLX until it's been a [couple of hours](https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues.tasks/create#body.request_body.FIELDS.task). To solve this, set a counter header `resendNumber` that increases for every resend and is included in the task name.

Also, I'm getting tired of generating releases, so I automated it. Next step might be to do the NPM release as well, but I'm ignoring that for now.