### PR TITLE
Allow both logger.warn and logger.warning

### DIFF
--- a/lib/cloud-tasks/router.js
+++ b/lib/cloud-tasks/router.js
@@ -11,6 +11,11 @@ import jobStorage from "../job-storage/index.js";
 import { sendToDlx } from "./dlx.js";
 import resend from "./resend.js";
 
+// Ugly hack to make lu-logger accept the same interface as pino.
+// When all workers have been migrated, we'll rewrite them to use lu-logger
+// directly, and then we can remove this
+logger.warn = logger.warning;
+
 export default function cloudTasksRouter(recipes = [], triggers = {}) {
   const router = expressRouter();
   router.use(middlewareRouter);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/b0rker",
-      "version": "9.0.1",
+      "version": "9.0.2",
       "license": "MIT",
       "dependencies": {
         "@bonniernews/gcp-push-metrics": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
This is a temp fix while some sequences run on cloud tasks (which use `lu-logger`, which is a wrapper around `winston`) and others on pubsub (which use `pino`).