### PR TITLE
Allow multiple sequence runs per correlation ID

### DIFF
--- a/lib/cloud-tasks/middleware/attributes.js
+++ b/lib/cloud-tasks/middleware/attributes.js
@@ -24,6 +24,9 @@ export function setAttributes(req, res, next) {
     siblingCount: parseInt(req.header("siblingCount")) || undefined,
     idempotencyKey: req.header("idempotencyKey"),
     subSequenceNo: req.header("subSequenceNo"),
+    // `runId` is set (and passed on) to easily distinguish between different runs
+    // of the same sequence with the same correlation ID
+    runId: req.header("runId") || uuid.v4(),
     resendNumber: parseInt(req.header("resendNumber")) || undefined,
     retryCount: parseInt(req.header("x-cloudtasks-taskretrycount") || "0"),
     queue: req.header("x-cloudtasks-queuename"),

--- a/lib/cloud-tasks/publish-task.js
+++ b/lib/cloud-tasks/publish-task.js
@@ -3,6 +3,7 @@ import config from "exp-config";
 import luLogger, { logger } from "lu-logger";
 import gax from "google-gax";
 import * as uuid from "uuid";
+import crypto from "crypto";
 
 import { filterUndefinedNullValues } from "./utils.js";
 
@@ -59,7 +60,7 @@ export async function publishTask(taskUrl, body, headers = {}, queue = "default"
   await cloudTasksClient.createTask({
     parent: queueName,
     task: {
-      name: taskNameFromUrl(taskUrl, queueName, correlationId, headers?.resendNumber),
+      name: buildTaskName(taskUrl, body, queueName, correlationId, headers?.resendNumber),
       httpRequest: {
         httpMethod: "POST",
         headers: newHeaders,
@@ -75,15 +76,22 @@ async function setTimer(delaySeconds) {
   return await new Promise((resolve) => setTimeout(resolve, delaySeconds * 1000));
 }
 
-function taskNameFromUrl(url, queueName, correlationId, resendNumber) {
+function buildTaskName(url, body, queueName, correlationId, resendNumber) {
   // Task name can only contain letters, numbers, underscores and hyphens, and must be at most 500 characters
   const urlForName = url.replace(/^\//, ""); // Remove leading slash
-  const suffix = resendNumber ? `__${correlationId}__re${resendNumber}` : `__${correlationId}`;
+  const hash = createMessageHash(body);
+  const resendSuffix = resendNumber ? `__re${resendNumber}` : "";
+  const suffix = `__${hash}__${correlationId}${resendSuffix}`;
+
   const truncated = truncateName(urlForName, suffix);
   const truncatedAndNormalized = truncated.replace(/[^\w-]/g, "_");
   return `${queueName}/tasks/${truncatedAndNormalized}`;
 }
 
+function createMessageHash(message) {
+  return crypto.createHash("sha256").update(JSON.stringify(message)).digest("base64");
+}
+
 function truncateName(name, suffix, maxLength = 500) {
-  return (name.substring(0, maxLength - suffix.length) + suffix);
+  return name.substring(0, maxLength - suffix.length) + suffix;
 }

--- a/lib/cloud-tasks/router.js
+++ b/lib/cloud-tasks/router.js
@@ -50,20 +50,20 @@ function buildCloudTaskSequenceRoutes(router, { namespace, name, sequence, unrec
 
 function startSequence({ key: firstKeyInSequence, queue }) {
   return async (req, res) => {
-    const { correlationId, parentCorrelationId, siblingCount } = req.attributes;
+    const { correlationId, parentCorrelationId, siblingCount, runId } = req.attributes;
     await publishTask(
       `${req.attributes.relativeUrl}/${firstKeyInSequence.replace(/^\./, "")}`,
       appendData(req.body, []), // Ensure we have a data element
-      { correlationId, parentCorrelationId, siblingCount },
+      { correlationId, parentCorrelationId, siblingCount, runId },
       queue
     );
-    res.status(201).send({ correlationId });
+    res.status(201).send({ correlationId, runId });
   };
 }
 
 function messageHandler(func, { nextKey, queue } = {}) {
   return async (req, res) => {
-    const { key, correlationId, parentCorrelationId, siblingCount } = req.attributes;
+    const { key, correlationId, parentCorrelationId, siblingCount, runId } = req.attributes;
     const context = { ...buildContext(correlationId, key), logger }; // Overwrite the logger with the one from lu-logger;
 
     const result = await func(req.body, context);
@@ -76,11 +76,16 @@ function messageHandler(func, { nextKey, queue } = {}) {
     }
 
     if (nextKey) {
-      await publishTask(keyToUrl(nextKey), nextBody, { correlationId, parentCorrelationId, siblingCount }, queue);
+      await publishTask(
+        keyToUrl(nextKey),
+        nextBody,
+        { correlationId, parentCorrelationId, siblingCount, runId },
+        queue
+      );
     } else {
       logger.info("No more steps in this sequence");
     }
-    res.status(201).send({ correlationId });
+    res.status(201).send({ correlationId, runId });
   };
 }
 
@@ -88,7 +93,7 @@ async function handleTriggerResult(
   result,
   body,
   { nextKey, queue },
-  { key, correlationId, parentCorrelationId, siblingCount }
+  { key, correlationId, parentCorrelationId, siblingCount, runId }
 ) {
   const errorMessage = checkForTriggerError(result);
   if (errorMessage) {
@@ -101,7 +106,7 @@ async function handleTriggerResult(
     if (result.messages.length > 0) {
       // If we start sub-sequences, spawn these, and then exit. The main sequence will be resumed
       // when the last child completes
-      await startSubSequences(result, `${key}:${correlationId}`, { nextKey, queue }, body);
+      await startSubSequences(result, `${key}:${correlationId}`, { nextKey, queue, runId }, body);
       return { message: "Sub-sequences started", status: 200 };
     }
   } else if ([ "sequence", "event" ].some((s) => result.key.startsWith(s))) {
@@ -128,17 +133,21 @@ function checkForTriggerError(result) {
   }
 }
 
-async function startSubSequences(result, parentCorrelationId, { nextKey, queue }, message) {
+async function startSubSequences(result, parentCorrelationId, { nextKey, queue, runId }, message) {
   const messages = result.messages.map((o) => ({
     body: o,
     headers: { parentCorrelationId, correlationId: uuid.v4() },
   }));
   logger.info(`Starting ${result.messages.length} subsequences`);
-  await jobStorage.storeParent(parentCorrelationId, messages, message, { nextKey, queue });
+  await jobStorage.storeParent(parentCorrelationId, messages, message, { nextKey, queue, runId });
   await publishTasksBulk(keyToUrl(result.key), messages);
 }
 
-async function triggerOtherSequences(originalMessage, result, { parentCorrelationId, correlationId, siblingCount }) {
+async function triggerOtherSequences(
+  originalMessage,
+  result,
+  { parentCorrelationId, correlationId, siblingCount }
+) {
   const messages = (result.messages || [ originalMessage ]).map((m, idx) => ({
     body: { ...m, data: [ ...(m.data ?? []) ], messages: undefined },
     headers: { parentCorrelationId, correlationId: `${correlationId}:${idx}`, siblingCount },
@@ -153,7 +162,7 @@ function unrecoverableHandler(unrecoverableFunc) {
       return res.status(200).send();
     }
 
-    const { key, correlationId, parentCorrelationId, siblingCount } = req.attributes;
+    const { key, correlationId, parentCorrelationId, siblingCount, runId } = req.attributes;
     const context = { ...buildContext(correlationId, key), logger }; // Overwrite the logger with the one from lu-logger;
 
     const result = await unrecoverableFunc(req.body, context);
@@ -162,15 +171,16 @@ function unrecoverableHandler(unrecoverableFunc) {
       correlationId,
       parentCorrelationId,
       siblingCount,
+      runId,
     });
     return res.status(200).send();
   };
 }
 
 async function processedHandler(req, res) {
-  const { key, correlationId, parentCorrelationId, siblingCount } = req.attributes;
+  const { key, correlationId, parentCorrelationId, siblingCount, runId } = req.attributes;
 
-  logger.info(`The sequence is finished: ${JSON.stringify(key, correlationId, parentCorrelationId, siblingCount)}`);
+  logger.info(`The sequence is finished: ${JSON.stringify({ key, correlationId, parentCorrelationId, siblingCount, runId })}`);
   const [ sequence ] = key.split(".");
 
   if (sequence !== "sub-sequence") return res.status(200).send();
@@ -195,10 +205,11 @@ async function processedHandler(req, res) {
     }
     const originalCorrelationId = parentCorrelationId.split(":").slice(1).join(":");
     const newBody = appendData(parentData.message, { type: key, id: completedJobCount });
+    const mainSeqeuenceRunId = parentData.nextKey.runId;
     await publishTask(
       keyToUrl(parentData.nextKey.nextKey),
       newBody,
-      { correlationId: originalCorrelationId },
+      { correlationId: originalCorrelationId, ...(mainSeqeuenceRunId && { runId: mainSeqeuenceRunId }) },
       parentData.nextKey?.queue
     );
   }

--- a/lib/job-storage/utils/job-storage-helper.js
+++ b/lib/job-storage/utils/job-storage-helper.js
@@ -29,12 +29,13 @@ function bucketHash(correlationId, numHashBuckets = config.jobStorageBuckets || 
   return (Math.abs(hash) % numHashBuckets).toString();
 }
 
-function parentPayload(message, nextKey, children, jobStorage) {
+function parentPayload(message, nextKey, children, jobStorage, other = {}) {
   // the max size of a firestore document is 1MB, so only include the bare minimum
   const payload = {
     startedJobsCount: children.length,
     message,
     nextKey,
+    ...other,
   };
   if (jobStorage === "memory") {
     payload.completedJobsCount = 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "9.0.2",
+  "version": "9.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/b0rker",
-      "version": "9.0.2",
+      "version": "9.1.0",
       "license": "MIT",
       "dependencies": {
         "@bonniernews/gcp-push-metrics": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "9.0.2",
+  "version": "9.1.0",
   "engines": {
     "node": ">=18"
   },

--- a/test/feature-cloud-tasks/dlx-feature.test.js
+++ b/test/feature-cloud-tasks/dlx-feature.test.js
@@ -115,6 +115,7 @@ Feature("Messages with too many retries get sent to the DLX", () => {
           key: "sequence.test.perform.http-step",
           origin: "cloudTasks",
           topic: "b0rker",
+          runId: fakePubSub.recordedMessages()[0].attributes.runId,
           appName: config.appName,
           relativeUrl: "sequence/test/perform.http-step",
           retryCount: (maxRetries + 1).toString(),

--- a/test/feature-cloud-tasks/resend-feature.test.js
+++ b/test/feature-cloud-tasks/resend-feature.test.js
@@ -56,13 +56,11 @@ Feature("Resending a stuck message", () => {
 
     And("the resend number should be included in the task names", () => {
       const queue = config.cloudTasks.queues.default;
-      response.messages
-        .map(({ taskName }) => taskName)
-        .should.eql([
-          `${queue}/tasks/sequence_test_perform_second__some-epic-id__re1`,
-          `${queue}/tasks/sequence_test_perform_third__some-epic-id`,
-          `${queue}/tasks/sequence_test_processed__some-epic-id`,
-        ]);
+      const [ taskName1, taskName2, taskName3 ] = response.messages.map(({ taskName }) => taskName);
+
+      taskName1.should.match(new RegExp(`${queue}/tasks/sequence_test_perform_second__.*__some-epic-id__re1`));
+      taskName2.should.match(new RegExp(`${queue}/tasks/sequence_test_perform_third__.*__some-epic-id`));
+      taskName3.should.match(new RegExp(`${queue}/tasks/sequence_test_processed__.*__some-epic-id`));
     });
   });
 
@@ -118,13 +116,11 @@ Feature("Resending a stuck message", () => {
 
     And("the resend number should be included in the task names", () => {
       const queue = config.cloudTasks.queues.default;
-      response.messages
-        .map(({ taskName }) => taskName)
-        .should.eql([
-          `${queue}/tasks/sequence_test_perform_second__some-epic-id__re4`,
-          `${queue}/tasks/sequence_test_perform_third__some-epic-id`,
-          `${queue}/tasks/sequence_test_processed__some-epic-id`,
-        ]);
+      const [ taskName1, taskName2, taskName3 ] = response.messages.map(({ taskName }) => taskName);
+
+      taskName1.should.match(new RegExp(`${queue}/tasks/sequence_test_perform_second__.*__some-epic-id__re4`));
+      taskName2.should.match(new RegExp(`${queue}/tasks/sequence_test_perform_third__.*__some-epic-id`));
+      taskName3.should.match(new RegExp(`${queue}/tasks/sequence_test_processed__.*__some-epic-id`));
     });
   });
 });

--- a/test/unit/publish-task.test.js
+++ b/test/unit/publish-task.test.js
@@ -1,0 +1,50 @@
+import { fakeCloudTasks } from "@bonniernews/lu-test";
+import express from "express";
+
+import { publishTask } from "../../lib/cloud-tasks/publish-task.js";
+
+describe("Cloud Task names", () => {
+  const broker = express();
+
+  beforeEach(() => fakeCloudTasks.enablePublish(broker));
+  afterEach(fakeCloudTasks.reset);
+
+  it("should never generate names longer than 500 characters", async () => {
+    const body = { foo: "bar" };
+    const taskName = "some-name_".repeat(52); // Just this is 520 characters, and more will be added
+
+    await publishTask(`/sequence/some-seq/${taskName}`, body, { correlationId: "some-id" });
+    await fakeCloudTasks.processMessages();
+
+    const messages = fakeCloudTasks.recordedMessages();
+    messages.length.should.eql(1);
+    messages[0].taskName.split("/").pop().length.should.eql(500);
+  });
+
+  it("should generate different names for different HTTP bodies with the same correlation ID", async () => {
+    const body1 = { foo: "bar" };
+    const body2 = { foo: "baz" };
+
+    await publishTask("/sequence/some-seq/perform.some-action", body1, { correlationId: "same-id" });
+    await publishTask("/sequence/some-seq/perform.some-action", body2, { correlationId: "same-id" });
+
+    await fakeCloudTasks.processMessages();
+
+    const messages = fakeCloudTasks.recordedMessages();
+    messages.length.should.eql(2);
+    messages[0].taskName.should.not.eql(messages[1].taskName);
+  });
+
+  it("should generate equal names for equal HTTP bodies with the same correlation ID", async () => {
+    const body = { foo: "bar" };
+
+    await publishTask("/sequence/some-seq/perform.some-action", body, { correlationId: "same-id" });
+    await publishTask("/sequence/some-seq/perform.some-action", body, { correlationId: "same-id" });
+
+    await fakeCloudTasks.processMessages();
+
+    const messages = fakeCloudTasks.recordedMessages();
+    messages.length.should.eql(2);
+    messages[0].taskName.should.eql(messages[1].taskName);
+  });
+});


### PR DESCRIPTION
Add hash of message body to task name to allow several runs of a sequence with the same correlation ID (but still different messages). This way, we'll hopefully still get Cloud Task's deduplication if we try to publish the same message multiple times, but still allow two different messages to be received within the same HTTP request on the client side.

The background is that credentials is sending us several user updates within the same request on their end.

To further help in this case, I'm introducing a `runId`, which is set each time a sequence is started, and identifies that specific run, even if the correlation ID is reused. It is intentionally **not** passed on to subsequences and other triggers, since its purpose is to identify this particular run of this particular sequence.

Note that sequences with subsequences probably won't work when using the same correlation ID, since it's used as the key in Firestore, and reusing it will most likely result in a conflict.