### PR TITLE
Send trigger message to DLX if initial Cloud Tasks publication fails

### DIFF
--- a/lib/cloud-tasks/error-handler.js
+++ b/lib/cloud-tasks/error-handler.js
@@ -36,5 +36,12 @@ export async function errorHandler(err, req, res, next) {
   }
 
   logger.error(`Unexpected error ${err.message}: ${err.stack}`);
+
+  // If the request was not sent from cloud tasks, send it to the DLX so that it can be resent
+  if (!req.attributes.queue) {
+    const sequenceOrTrigger = req.attributes.relativeUrl.split("/").filter(Boolean).shift();
+    await sendToDlx(req, `Failed to start ${sequenceOrTrigger}`);
+  }
+
   return res.status(500).send({ type: "unknown", message: err.message });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "mocha-cakes-2": "^3.3.0",
         "nock": "^13.4.0",
         "prettier": "^3.1.0",
+        "sinon": "^17.0.1",
         "supertest": "^6.3.3",
         "test-data": "file:./test/data"
       },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "mocha-cakes-2": "^3.3.0",
     "nock": "^13.4.0",
     "prettier": "^3.1.0",
+    "sinon": "^17.0.1",
     "supertest": "^6.3.3",
     "test-data": "file:./test/data"
   },


### PR DESCRIPTION
Today, if e.g. an order fails because cloud tasks throws an error in the initial call, that order is lost (apart from logs). This way, we send it to the DLX instead, so that it can be resent.