### PR TITLE
Fix: don't throw away the error message when sending to DLX

### DIFF
--- a/lib/cloud-tasks/dlx.js
+++ b/lib/cloud-tasks/dlx.js
@@ -4,8 +4,9 @@ import { rejectMessage } from "../publish-message.js";
 import { filterUndefinedNullValues } from "./utils.js";
 
 export async function sendToDlx(req, errorMessage) {
+  const message = errorMessage || req.body?.error?.message;
   await rejectMessage(
-    { ...req.body, error: { message: errorMessage } },
+    { ...req.body, error: { ...req.body?.error, message } },
     {
       origin: "cloudTasks",
       appName: config.appName,


### PR DESCRIPTION
Currently, if `req.body.error.message` is set, it gets overwritten when sending to the DLX. This has caused some issues on the DLX when resending messages from the `unrecoverable` handler.