### PR TITLE
Fix: Remove 50 children in a transaction instead of 100

### DIFF
--- a/lib/job-storage/firestore-job-storage.js
+++ b/lib/job-storage/firestore-job-storage.js
@@ -97,9 +97,9 @@ async function removeParent(parentCorrelationId) {
     }
     await parentDoc.ref.delete();
 
-    // remove all children, in chunks of 100
+    // remove all children, in chunks of 50
     const bucketsRef = db.collection(parentCorrelationId);
-    const query = bucketsRef.orderBy("__name__").limit(100);
+    const query = bucketsRef.orderBy("__name__").limit(50);
 
     let snapshot;
     while ((snapshot = await query.get()).size > 0) {


### PR DESCRIPTION
Lab firestore complained that the transaction was too big with 100 children at once, so try with 50 instead