### PR TITLE
Attempt to fix DEADLINE_EXCEEDED bug

### DIFF
--- a/lib/cloud-tasks/publish-task.js
+++ b/lib/cloud-tasks/publish-task.js
@@ -7,17 +7,22 @@ import crypto from "crypto";
 
 import { filterUndefinedNullValues } from "./utils.js";
 
-const { queues, selfUrl, localPort } = config.cloudTasks || {};
-const cloudTasksClient = new CloudTasksClient(
-  localPort
-    ? {
-      port: localPort,
-      servicePath: "localhost",
-      sslCreds: gax.ChannelCredentials.createInsecure(),
-    }
-    : {},
-  gax
-);
+const { queues, selfUrl, localPort, useHttpFallback } = config.cloudTasks || {};
+const cloudTasksClient = getCloudTasksClient();
+
+function getCloudTasksClient() {
+  if (useHttpFallback) return new CloudTasksClient({ fallback: true });
+  return new CloudTasksClient(
+    localPort
+      ? {
+        port: localPort,
+        servicePath: "localhost",
+        sslCreds: gax.ChannelCredentials.createInsecure(),
+      }
+      : {},
+    gax
+  );
+}
 
 // Google recommends to rate limit the amount of published tasks per second
 const maxTasksPublishedPerSecond = 500;
@@ -59,17 +64,17 @@ export async function publishTask(taskUrl, body, headers = {}, queue = "default"
   logger.info(`Sending task ${JSON.stringify(body)} with headers ${JSON.stringify(newHeaders)} to ${url}`);
   await cloudTasksClient.createTask(
     {
-    parent: queueName,
-    task: {
-      name: buildTaskName(taskUrl, body, queueName, correlationId, headers?.resendNumber),
-      httpRequest: {
-        httpMethod: "POST",
-        headers: newHeaders,
-        url,
-        body: Buffer.from(JSON.stringify(body, null, 2)),
-        dispatchDeadline: 30 * 60, // 30 minutes
+      parent: queueName,
+      task: {
+        name: buildTaskName(taskUrl, body, queueName, correlationId, headers?.resendNumber),
+        httpRequest: {
+          httpMethod: "POST",
+          headers: newHeaders,
+          url,
+          body: Buffer.from(JSON.stringify(body, null, 2)),
+          dispatchDeadline: 30 * 60, // 30 minutes
+        },
       },
-    },
     },
     { retry: { backoffSettings: { maxRetries: 5, initialRetryDelayMillis: 1000, retryDelayMultiplier: 2 } } }
   );

--- a/lib/cloud-tasks/publish-task.js
+++ b/lib/cloud-tasks/publish-task.js
@@ -57,7 +57,8 @@ export async function publishTask(taskUrl, body, headers = {}, queue = "default"
   };
   const queueName = queues[queue] || queues.default;
   logger.info(`Sending task ${JSON.stringify(body)} with headers ${JSON.stringify(newHeaders)} to ${url}`);
-  await cloudTasksClient.createTask({
+  await cloudTasksClient.createTask(
+    {
     parent: queueName,
     task: {
       name: buildTaskName(taskUrl, body, queueName, correlationId, headers?.resendNumber),
@@ -69,7 +70,9 @@ export async function publishTask(taskUrl, body, headers = {}, queue = "default"
         dispatchDeadline: 30 * 60, // 30 minutes
       },
     },
-  });
+    },
+    { retry: { backoffSettings: { maxRetries: 5, initialRetryDelayMillis: 1000, retryDelayMultiplier: 2 } } }
+  );
 }
 
 async function setTimer(delaySeconds) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "9.2.2",
+  "version": "9.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/b0rker",
-      "version": "9.2.2",
+      "version": "9.3.0",
       "license": "MIT",
       "dependencies": {
         "@bonniernews/gcp-push-metrics": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -544,50 +544,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@google-cloud/pubsub/node_modules/@grpc/grpc-js": {
-      "version": "1.9.13",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.13.tgz",
-      "integrity": "sha512-OEZZu9v9AA+7/tghMDE8o5DAMD5THVnwSqDWuh7PPYO5287rTyqy0xEHT6/e4pbqSrhyLPdQFsam4TwFQVVIIw==",
-      "dependencies": {
-        "@grpc/proto-loader": "^0.7.8",
-        "@types/node": ">=12.12.47"
-      },
-      "engines": {
-        "node": "^8.13.0 || >=10.10.0"
-      }
-    },
-    "node_modules/@google-cloud/pubsub/node_modules/google-gax": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.0.5.tgz",
-      "integrity": "sha512-yLoYtp4zE+8OQA74oBEbNkbzI6c95W01JSL7RqC8XERKpRvj3ytZp1dgnbA6G9aRsc8pZB25xWYBcCmrbYOEhA==",
-      "dependencies": {
-        "@grpc/grpc-js": "~1.9.6",
-        "@grpc/proto-loader": "^0.7.0",
-        "@types/long": "^4.0.0",
-        "abort-controller": "^3.0.0",
-        "duplexify": "^4.0.0",
-        "google-auth-library": "^9.0.0",
-        "node-fetch": "^2.6.1",
-        "object-hash": "^3.0.0",
-        "proto3-json-serializer": "^2.0.0",
-        "protobufjs": "7.2.5",
-        "retry-request": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@google-cloud/pubsub/node_modules/proto3-json-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.0.tgz",
-      "integrity": "sha512-FB/YaNrpiPkyQNSNPilpn8qn0KdEfkgmJ9JP93PQyF/U4bAiXY5BiUdDhiDO4S48uSQ6AesklgVlrKiqZPzegw==",
-      "dependencies": {
-        "protobufjs": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@google-cloud/storage": {
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.7.0.tgz",
@@ -626,58 +582,14 @@
       }
     },
     "node_modules/@google-cloud/tasks": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/tasks/-/tasks-5.1.1.tgz",
-      "integrity": "sha512-ZcKRanT4gxnTll77e8FOt210db6NSFAQYn1Z6T7BPubd7vBJWp9d6Zbbntnl50vhw84YTbZH+gqfsPSQEShQyQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/tasks/-/tasks-5.3.0.tgz",
+      "integrity": "sha512-hHgk/blNgjnaH9HVPE7hvjPaC8RTRQnTnbJZVCUMJKias9G5GaZyfc1tLvRI7oIpVMSxinVSTkcCHS/sKYFlxw==",
       "dependencies": {
         "google-gax": "^4.0.4"
       },
       "engines": {
         "node": ">=v14"
-      }
-    },
-    "node_modules/@google-cloud/tasks/node_modules/@grpc/grpc-js": {
-      "version": "1.9.13",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.13.tgz",
-      "integrity": "sha512-OEZZu9v9AA+7/tghMDE8o5DAMD5THVnwSqDWuh7PPYO5287rTyqy0xEHT6/e4pbqSrhyLPdQFsam4TwFQVVIIw==",
-      "dependencies": {
-        "@grpc/proto-loader": "^0.7.8",
-        "@types/node": ">=12.12.47"
-      },
-      "engines": {
-        "node": "^8.13.0 || >=10.10.0"
-      }
-    },
-    "node_modules/@google-cloud/tasks/node_modules/google-gax": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.0.5.tgz",
-      "integrity": "sha512-yLoYtp4zE+8OQA74oBEbNkbzI6c95W01JSL7RqC8XERKpRvj3ytZp1dgnbA6G9aRsc8pZB25xWYBcCmrbYOEhA==",
-      "dependencies": {
-        "@grpc/grpc-js": "~1.9.6",
-        "@grpc/proto-loader": "^0.7.0",
-        "@types/long": "^4.0.0",
-        "abort-controller": "^3.0.0",
-        "duplexify": "^4.0.0",
-        "google-auth-library": "^9.0.0",
-        "node-fetch": "^2.6.1",
-        "object-hash": "^3.0.0",
-        "proto3-json-serializer": "^2.0.0",
-        "protobufjs": "7.2.5",
-        "retry-request": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@google-cloud/tasks/node_modules/proto3-json-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.0.tgz",
-      "integrity": "sha512-FB/YaNrpiPkyQNSNPilpn8qn0KdEfkgmJ9JP93PQyF/U4bAiXY5BiUdDhiDO4S48uSQ6AesklgVlrKiqZPzegw==",
-      "dependencies": {
-        "protobufjs": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@grpc/grpc-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "9.2.2",
+  "version": "9.3.0",
   "engines": {
     "node": ">=18"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@bonniernews/gcp-push-metrics": "^4.0.0",
     "@google-cloud/firestore": "^7.6.0",
     "@google-cloud/pubsub": "^4.0.7",
-    "@google-cloud/tasks": "^5.1.1",
+    "@google-cloud/tasks": "^5.3.0",
     "axios": "^1.6.2",
     "camelcase": "^8.0.0",
     "exp-config": "^4.2.1",


### PR DESCRIPTION
According to Google, the issue with publishing Cloud Tasks is in the client library, so we'll try a couple of things:

- Bump the client library to the latest version (the one we had is not that old, I don't suspect this will do anything)
- Add retry config to publication
- Add a setting to publish tasks using HTTP instead of gRPC (as suggested in [this GitHub issue](https://github.com/googleapis/nodejs-tasks/issues/397))