### PR TITLE
Catch cloud tasks deduplication errors

### DIFF
--- a/lib/cloud-tasks/error-handler.js
+++ b/lib/cloud-tasks/error-handler.js
@@ -30,11 +30,6 @@ export async function errorHandler(err, req, res, next) {
     return res.status(200).send({ type: "unrecoverable", message: err.extraMessage });
   }
 
-  if (err.message.startsWith("6 ALREADY_EXISTS: The task cannot be created because a task with this name existed too recently")) {
-    logger.info(`Cloud tasks handled deduplication (this is OK): ${err.message}: ${err.stack}`);
-    return res.status(200).send({ type: "already_published", message: err.message });
-  }
-
   logger.error(`Unexpected error ${err.message}: ${err.stack}`);
 
   // If the request was not sent from cloud tasks, send it to the DLX so that it can be resent

--- a/lib/cloud-tasks/publish-task.js
+++ b/lib/cloud-tasks/publish-task.js
@@ -51,6 +51,22 @@ export async function publishTasksBulk(taskUrl, messages) {
 }
 
 export async function publishTask(taskUrl, body, headers = {}, queue = "default") {
+  const cloudTasksDeduplicationErrors = [
+    "Requested entity already exists",
+    "The task cannot be created because a task with this name existed too recently",
+  ];
+  try {
+    await _publishTask(taskUrl, body, headers, queue);
+  } catch (err) {
+    if (cloudTasksDeduplicationErrors.some((msg) => err.message?.includes(msg))) {
+      logger.warning(`Cloud tasks handled deduplication (this should be OK): ${err.message}: ${err.stack}`);
+      return;
+    }
+    throw err;
+  }
+}
+
+async function _publishTask(taskUrl, body, headers = {}, queue = "default") {
   const url = `${selfUrl}/v2/${taskUrl.replace(/^\//, "")}`;
   const correlationId =
     headers.correlationId || headers["correlation-id"] || luLogger.debugMeta.getDebugMeta().correlationId;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "9.3.0",
+  "version": "9.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/b0rker",
-      "version": "9.3.0",
+      "version": "9.4.0",
       "license": "MIT",
       "dependencies": {
         "@bonniernews/gcp-push-metrics": "^4.0.0",
         "@google-cloud/firestore": "^7.6.0",
         "@google-cloud/pubsub": "^4.0.7",
-        "@google-cloud/tasks": "^5.1.1",
+        "@google-cloud/tasks": "^5.3.0",
         "axios": "^1.6.2",
         "camelcase": "^8.0.0",
         "exp-config": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "9.3.0",
+  "version": "9.4.0",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
These are raised when the task has already been published and should not be an error. We still log it as a warning, in case this happens when we don't want it to.

Should remove a log of these from the DLX/error logs.