### PR TITLE
Fix so that trigger keys are backwards compatible

### DIFF
--- a/lib/cloud-tasks/router.js
+++ b/lib/cloud-tasks/router.js
@@ -103,7 +103,7 @@ async function handleTriggerResult(
     return { message: errorMessage, status: 400 };
   }
 
-  result.key = result.key.replace("trigger.", "");
+  result.key = result.key.replace("trigger.", "").replace(/^\./, "");
   if (result.key.startsWith("sub-sequence")) {
     if (result.messages.length > 0) {
       if (grandParentCorrelationId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "9.4.1",
+  "version": "9.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/b0rker",
-      "version": "9.4.1",
+      "version": "9.4.2",
       "license": "MIT",
       "dependencies": {
         "@bonniernews/gcp-push-metrics": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "9.4.1",
+  "version": "9.4.2",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
This makes it so that trigger keys with a leading period
```js
{
  type: "trigger",
  key: ".sequence.foo",
}
```
also works.