### PR TITLE
Add retry of cloud tasks publication

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -15,7 +15,8 @@
     "queues": {
       "default": "projects/project-id/locations/location/queues/foo-queue",
       "concurrencyLimited": "projects/project-id/locations/location/queues/limited-queue"
-    }
+    },
+    "maxPublicationRetries": 5
   },
   "maxResumeCount": 10,
   "gcpProxy": {

--- a/config/test.json
+++ b/config/test.json
@@ -15,7 +15,8 @@
     "queues": {
       "default": "projects/project-id/locations/location/queues/foo-queue",
       "concurrencyLimited": "projects/project-id/locations/location/queues/limited-queue"
-    }
+    },
+    "maxPublicationRetries": 0
   },
   "gcpProxy": {
     "url": "https://some-base.local",

--- a/lib/cloud-tasks/publish-task.js
+++ b/lib/cloud-tasks/publish-task.js
@@ -7,6 +7,7 @@ import crypto from "crypto";
 
 import { filterUndefinedNullValues } from "./utils.js";
 import setTimer from "../utils/timer.js";
+import withRetries from "../utils/retry.js";
 
 const { queues, selfUrl, localPort, useHttpFallback } = config.cloudTasks || {};
 const cloudTasksClient = getCloudTasksClient();
@@ -27,6 +28,7 @@ function getCloudTasksClient() {
 
 // Google recommends to rate limit the amount of published tasks per second
 const maxTasksPublishedPerSecond = 500;
+const maxRetries = config.cloudTasks?.maxPublicationRetries ?? 5;
 
 export async function publishTasksBulk(taskUrl, messages) {
   const numTasks = messages.length;
@@ -56,15 +58,20 @@ export async function publishTask(taskUrl, body, headers = {}, queue = "default"
     "Requested entity already exists",
     "The task cannot be created because a task with this name existed too recently",
   ];
-  try {
-    await _publishTask(taskUrl, body, headers, queue);
-  } catch (err) {
-    if (cloudTasksDeduplicationErrors.some((msg) => err.message?.includes(msg))) {
-      logger.warning(`Cloud tasks handled deduplication (this should be OK): ${err.message}: ${err.stack}`);
-      return;
-    }
-    throw err;
-  }
+  await withRetries(
+    async () => {
+      try {
+        await _publishTask(taskUrl, body, headers, queue);
+      } catch (err) {
+        if (cloudTasksDeduplicationErrors.some((msg) => err.message?.includes(msg))) {
+          logger.warning(`Cloud tasks handled deduplication (this should be OK): ${err.message}: ${err.stack}`);
+          return;
+        }
+        throw err;
+      }
+    },
+    { maxRetries }
+  );
 }
 
 async function _publishTask(taskUrl, body, headers = {}, queue = "default") {

--- a/lib/cloud-tasks/publish-task.js
+++ b/lib/cloud-tasks/publish-task.js
@@ -6,6 +6,7 @@ import * as uuid from "uuid";
 import crypto from "crypto";
 
 import { filterUndefinedNullValues } from "./utils.js";
+import setTimer from "../utils/timer.js";
 
 const { queues, selfUrl, localPort, useHttpFallback } = config.cloudTasks || {};
 const cloudTasksClient = getCloudTasksClient();
@@ -94,10 +95,6 @@ async function _publishTask(taskUrl, body, headers = {}, queue = "default") {
     },
     { retry: { backoffSettings: { maxRetries: 5, initialRetryDelayMillis: 1000, retryDelayMultiplier: 2 } } }
   );
-}
-
-async function setTimer(delaySeconds) {
-  return await new Promise((resolve) => setTimeout(resolve, delaySeconds * 1000));
 }
 
 function buildTaskName(url, body, queueName, correlationId, resendNumber) {

--- a/lib/utils/retry.js
+++ b/lib/utils/retry.js
@@ -1,0 +1,17 @@
+import { logger } from "lu-logger";
+
+import setTimer from "./timer.js";
+
+export default async function withRetries(func, { maxRetries = 5, initialDelay = 1 }) {
+  for (let retries = 0; retries <= maxRetries; retries++) {
+    try {
+      return await func();
+    } catch (err) {
+      if (retries >= maxRetries) {
+        throw err;
+      }
+      logger.warning(`Retrying after error: ${err.message}: ${err.stack}`);
+      await setTimer(initialDelay * 2 ** retries);
+    }
+  }
+}

--- a/lib/utils/timer.js
+++ b/lib/utils/timer.js
@@ -1,0 +1,3 @@
+export default async function setTimer(delaySeconds) {
+  return await new Promise((resolve) => setTimeout(resolve, delaySeconds * 1000));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "9.4.3",
+  "version": "9.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/b0rker",
-      "version": "9.4.3",
+      "version": "9.5.0",
       "license": "MIT",
       "dependencies": {
         "@bonniernews/gcp-push-metrics": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "9.4.3",
+  "version": "9.5.0",
   "engines": {
     "node": ">=18"
   },

--- a/test/unit/retry.test.js
+++ b/test/unit/retry.test.js
@@ -1,0 +1,43 @@
+import * as sinon from "sinon";
+
+import withRetries from "../../lib/utils/retry.js";
+
+describe("Retry", () => {
+  it("should not do anything if the function succeeds", async () => {
+    const testFunc = sinon.spy(() => "success");
+    const result = await withRetries(testFunc, { maxRetries: 3, initialDelay: 0 });
+
+    result.should.eql("success");
+    testFunc.callCount.should.eql(1);
+  });
+
+  it("should throw the exception after max retries", async () => {
+    const error = new Error("Test error");
+    const testFunc = sinon.spy(() => {
+      throw error;
+    });
+
+    try {
+      await withRetries(testFunc, { maxRetries: 3, initialDelay: 0 });
+    } catch (e) {
+      e.should.eql(error);
+    }
+
+    testFunc.callCount.should.eql(4);
+  });
+
+  it("should not throw if the function succeeds", async () => {
+    const error = new Error("Test error");
+    let attempts = 0;
+    const testFunc = sinon.spy(() => {
+      attempts++;
+      if (attempts < 3) throw error;
+      return "success";
+    });
+
+    const result = await withRetries(testFunc, { maxRetries: 3, initialDelay: 0 });
+
+    result.should.eql("success");
+    testFunc.callCount.should.eql(3);
+  });
+});


### PR DESCRIPTION
We've experienced some intermittent errors related to publishing cloud tasks, which is an issue when publishing subsequences and we crash somewhere in the middle. This PR adds a retry loop with an exponential backoff.