### PR TITLE
Better DLX error messages

### DIFF
--- a/lib/dlx.js
+++ b/lib/dlx.js
@@ -4,7 +4,12 @@ import { logger } from "lu-logger";
 
 import { filterUndefinedNullValues } from "./utils/sequences.js";
 
+const maxRetries = config.maxRetries || 10;
 const pubSubClient = new PubSub();
+
+export function shouldSendToDlx(req, { nextTime = false } = {}) {
+  return req.attributes.retryCount + (nextTime ? 1 : 0) > maxRetries;
+}
 
 export async function sendToDlx(req, errorMessage) {
   const message = errorMessage || req.body?.error?.message;
@@ -24,4 +29,11 @@ export async function sendToDlx(req, errorMessage) {
     logger.error(`Error publishing PubSub message: "${err}". Full message: ${JSON.stringify(message)}`);
     throw err;
   }
+}
+
+export async function ackAndSendToDlx(req, res, err) {
+  logger.error("Max retries reached, sending to DLX.");
+  const retryMessage = err?.extraMessage ? `Max retries reached. Last message: "${err.extraMessage}"` : "Max retries reached";
+  await sendToDlx(req, retryMessage);
+  return res.status(200).send({ type: "dlx", message: retryMessage });
 }

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,24 +1,28 @@
 import { logger } from "lu-logger";
 
-import { sendToDlx } from "./dlx.js";
+import { ackAndSendToDlx, sendToDlx, shouldSendToDlx } from "./dlx.js";
 import { publishTask } from "./publish-task.js";
 
 export async function errorHandler(err, req, res, next) {
   if (!err) return next();
 
   if (err.rejected) {
-    logger.info(`Rejected message: '${err.extraMessage}'. Message: ${JSON.stringify(req.body)}`);
+    logger.info(`Rejected message: '${err.extraMessage}'`);
     await sendToDlx(req, err.extraMessage);
     return res.status(200).send({ type: "reject", message: err.extraMessage });
   }
 
   if (err.retry) {
-    logger.warning(`Retrying message: '${err.extraMessage}'. Message: ${JSON.stringify(req.body)}`);
-    return res.status(400).send({ type: "retry", message: err.extraMessage });
+    if (shouldSendToDlx(req, { nextTime: true })) {
+      return await ackAndSendToDlx(req, res, err);
+    } else {
+      logger.warning(`Retrying message: '${err.extraMessage}' `);
+      return res.status(400).send({ type: "retry", message: err.extraMessage });
+    }
   }
 
   if (err.unrecoverable) {
-    logger.info(`Unrecoverable message with message: '${err.extraMessage}'. Message: ${JSON.stringify(req.body)}`);
+    logger.info(`Unrecoverable message with message: '${err.extraMessage}'  `);
     // Trigger the unrecoverable handler
     if (!req.attributes.key.endsWith(".unrecoverable")) {
       await publishTask(
@@ -36,6 +40,10 @@ export async function errorHandler(err, req, res, next) {
   if (!req.attributes.queue) {
     const sequenceOrTrigger = req.attributes.relativeUrl.split("/").filter(Boolean).shift();
     await sendToDlx(req, `Failed to start ${sequenceOrTrigger}`);
+  }
+
+  if (shouldSendToDlx(req, { nextTime: true })) {
+    return await ackAndSendToDlx(req, res, err);
   }
 
   return res.status(500).send({ type: "unknown", message: err.message });

--- a/lib/http.js
+++ b/lib/http.js
@@ -88,6 +88,7 @@ function buildVerboseError(method, params, response) {
   );
   const error = new Error(msg);
   error.statusCode = response.statusCode;
+  error.extraMessage = msg;
 
   return error;
 }

--- a/lib/middleware/dlx.js
+++ b/lib/middleware/dlx.js
@@ -1,16 +1,8 @@
-import config from "exp-config";
-import { logger } from "lu-logger";
-
-import { sendToDlx } from "../dlx.js";
-
-const maxRetries = config.maxRetries || 10;
+import { ackAndSendToDlx, shouldSendToDlx } from "../dlx.js";
 
 export async function sendToDlxMiddleware(req, res, next) {
-  if (req.attributes.retryCount > maxRetries) {
-    logger.error("Max retries reached, sending to DLX");
-    await sendToDlx(req, "Max retries reached");
-
-    return res.status(200).send({ type: "dlx", message: "Max retries reached" });
+  if (shouldSendToDlx(req)) {
+    return await ackAndSendToDlx(req, res);
   }
   next();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "10.0.2",
+  "version": "10.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/b0rker",
-      "version": "10.0.2",
+      "version": "10.1.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/firestore": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/b0rker",
-  "version": "10.0.2",
+  "version": "10.1.0",
   "engines": {
     "node": ">=18"
   },

--- a/test/feature/dlx-feature.test.js
+++ b/test/feature/dlx-feature.test.js
@@ -127,6 +127,78 @@ Feature("Messages with too many retries get sent to the DLX", () => {
   });
 });
 
+Feature("Manual retry gets sent to DLX", () => {
+  afterEachScenario(() => {
+    fakeCloudTasks.reset();
+    fakePubSub.reset();
+  });
+
+  Scenario("A message gets retried the last time", () => {
+    const manualRetryMessage = "Manual retry message";
+    let broker;
+    Given("broker is initiated with a recipe", () => {
+      broker = start({
+        startServer: false,
+        recipes: [
+          {
+            namespace: "sequence",
+            name: "test",
+            sequence: [
+              route(".perform.http-step", (_, { retryIf }) => {
+                retryIf(true, manualRetryMessage);
+              }),
+            ],
+          },
+        ],
+      });
+    });
+
+    And("we can publish cloud tasks", () => {
+      fakeCloudTasks.enablePublish(broker);
+    });
+
+    And("we can publish pubsub messages", () => {
+      fakePubSub.enablePublish(broker);
+    });
+
+    let response;
+    When("a specific message is received", async () => {
+      response = await request(broker)
+        .post("/v2/sequence/test/perform.http-step")
+        .send({})
+        .set({ "X-CloudTasks-TaskRetryCount": maxRetries, "correlation-id": "some-epic-id" });
+      await fakeCloudTasks.processMessages();
+    });
+
+    Then("the status code should be 200 OK", () => {
+      response.statusCode.should.eql(200, response.text);
+      response.body.should.eql({ type: "dlx", message: `Max retries reached. Last message: "${manualRetryMessage}"` });
+    });
+
+    But("there should be no more processed messages", () => {
+      fakeCloudTasks.recordedMessages().length.should.eql(0);
+    });
+
+    And("the message should have been sent to the DLX", () => {
+      fakePubSub.recordedMessages().length.should.eql(1);
+      fakePubSub.recordedMessages()[0].should.deep.eql({
+        deliveryAttempt: 1,
+        message: { error: { message: `Max retries reached. Last message: "${manualRetryMessage}"` } },
+        topic: config.deadLetterTopic,
+        attributes: {
+          correlationId: "some-epic-id",
+          key: "sequence.test.perform.http-step",
+          origin: "cloudTasks",
+          runId: fakePubSub.recordedMessages()[0].attributes.runId,
+          appName: config.appName,
+          relativeUrl: "sequence/test/perform.http-step",
+          retryCount: maxRetries.toString(),
+        },
+      });
+    });
+  });
+});
+
 Feature("Sequence trigger failure gets sent to the DLX", () => {
   const sandbox = createSandbox();
 


### PR DESCRIPTION
By checking whether a message should be sent to the DLX in the error handler (i.e. after the lambda has run and errored), we can get the message set in e.g. `retryIf` and show it on the DLX.

This will also save one cloud tasks retry roundtrip, since we don't have to send e.g. retry 10 back just for retry 11 to be sent directly to the DLX before running the lambda.

Also set the `extraMessage` on all HTTP errors, we should also get HTTP error messages on the DLX when these fail after too many retries.